### PR TITLE
feat: bold homepage redesign — editorial layout, hero amplification & polish

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,58 @@
+# Design Context — ryanschill.co
+
+## Users
+
+**Primary:** Hiring managers at product companies and agency/freelance clients evaluating Ryan for senior frontend roles or contract work.
+
+**Context:** They are confirming design and development skills/expertise — they want to see *taste*, not just competence. They arrive skeptical of generic dev portfolios and leave when nothing surprises them.
+
+**Job to be done:** Confirm that Ryan can design *and* build at a high level, that he has genuine range (not just frontend-by-accident), and that working with him would be a quality experience.
+
+**Emotional arc:** Visitors should feel warmly welcomed, then intellectually curious, then quietly impressed. The site should feel handcrafted — like something found at a craft fair, not assembled from a template.
+
+---
+
+## Brand Personality
+
+**Three words: Crafted. Editorial. Alive.**
+
+- **Crafted** — the artisan analogy is central. Every pixel should feel deliberately placed, not defaulted to. This is the software equivalent of something made by hand at a craft fair: high quality, idiosyncratic, human.
+- **Editorial** — Ryan is a journalist and author as well as an engineer. Every element should have a point of view. Nothing is filler. Typography, structure, and hierarchy carry as much meaning as the words.
+- **Alive** — warm, curious, expressive. The site should breathe rather than sit still. Not corporate, not cold, not generic.
+
+**Range is a feature, not a footnote.** The engineering is better because of the journalism and art. The journalism is better because of the engineering and art. The multidisciplinary identity should feel cohesive and mutually reinforcing — a genuine strength, not an identity crisis.
+
+---
+
+## Aesthetic Direction
+
+**Direction:** Expressive editorial — think independent literary magazine meets premium craft brand, executed with frontend mastery.
+
+**Current state:** The token system and components are refined and conservative by default. This was not intentional restraint — bolder, more expressive direction is actively welcome in future work.
+
+**Visual tone:**
+- Rich typography as the primary design element
+- Color used with intention and confidence, not timidity
+- Generous white space punctuated by moments of visual drama
+- Layouts that feel composed, not grid-locked
+- Texture and warmth over sterile precision
+
+**Theme:** Full light/dark mode support. Both should feel intentional and equally resolved.
+
+**References to pursue:** Independent literary publications, premium craft/maker brands, editorial design that respects the reader's intelligence.
+
+**Anti-references:** Generic developer portfolios (dark bg + green code font + project cards), corporate SaaS design, anything that feels assembled rather than authored.
+
+---
+
+## Design Principles
+
+1. **Make it feel authored.** Every layout, typographic choice, and interaction should feel like a deliberate decision by someone with taste — not a framework default or a template deviation.
+
+2. **Bold is not loud.** Expressiveness comes from confidence in proportion, typography, and color — not decoration for its own sake. Be bold in the things that matter; be quiet where quiet serves.
+
+3. **The site is the portfolio.** Technical decisions should be demonstrable and intentional. The CSS architecture, animation system, and progressive enhancement *are* portfolio pieces. Don't hide the craft; surface it.
+
+4. **Range as coherence.** Engineering, writing, and art appear on the same site because they inform each other. Design choices should reinforce this — a unified sensibility across domains, not separate modes for each.
+
+5. **Warmth before formality.** The site speaks to senior hiring managers and clients, but it should never feel stiff or corporate. Intellectually serious, yes. Cold or performative, never.

--- a/_templates/home.html
+++ b/_templates/home.html
@@ -73,9 +73,12 @@
       <div class="container">
         <div class="hero__inner">
           <div class="hero__content">
-            <span class="type-eyebrow">Front-end engineer · Author · Artist</span>
+            <span class="type-eyebrow">
+              <span class="accent-mark" aria-hidden="true"></span>
+              Front-end engineer · Author · Artist
+            </span>
             <h1 id="hero-heading" class="hero__headline">
-              Crafted
+              <span class="hero__headline-static">Crafted</span>
               <span
                 class="hero__rotator"
                 id="hero-rotator"
@@ -91,20 +94,15 @@
               <a href="/work/" class="btn btn--primary btn--arrow btn--lg">View my work</a>
               <a href="/writing/" class="btn btn--outline btn--lg">Read my writing</a>
             </div>
-            <div class="hero__meta">
-              <span class="tag tag--tech">Angular</span>
-              <span class="tag tag--tech">TypeScript</span>
-              <span class="tag tag--tech">AI-assisted dev</span>
-              <span class="tag tag--tech">10+ years</span>
-            </div>
           </div>
           <div class="hero__photo" aria-hidden="true">
+            <span class="hero__rs-deco">RS</span>
             <div class="hero__photo-frame">
               <img
                 src="/img/headshot.jpg"
                 alt="Ryan Schill"
-                width="480"
-                height="600"
+                width="520"
+                height="650"
                 loading="eager"
                 fetchpriority="high"
               >
@@ -122,7 +120,7 @@
           <span class="type-label">Selected work</span>
           <h2 id="work-heading">Things I've built.</h2>
         </header>
-        <div class="grid-portfolio" role="list">
+        <div class="work-showcase">
           <!-- GENERATED:home-project-cards -->
           <!-- /GENERATED:home-project-cards -->
         </div>
@@ -142,7 +140,7 @@
           </div>
           <a href="/writing/" class="btn btn--ghost btn--arrow">All posts</a>
         </header>
-        <div class="grid-writing">
+        <div class="grid-writing grid-writing--home">
           <!-- GENERATED:home-post-cards -->
           <!-- /GENERATED:home-post-cards -->
         </div>
@@ -163,15 +161,15 @@
             >
           </div>
           <div class="about-strip__content">
-            <span class="type-label" style="--mark-color: var(--ember-600)">About</span>
+            <span class="type-label">About</span>
             <h2 id="about-heading">I'm Ryan.</h2>
-            <p class="type-lead" style="color: var(--ink-700); margin-bottom: var(--space-6);">
+            <p class="type-lead">
               Senior front-end engineer by day. Author and visual artist by night. Journalist by training.
             </p>
-            <p style="color: var(--ink-700); margin-bottom: var(--space-8); line-height: 1.8; font-size: var(--scale-md);">
+            <p>
               I've spent a decade building front-end applications at companies like IBM, ADP, Vanguard, and NBCUniversal. Before that, I spent years writing, reporting on juvenile justice, editing and managing a newsroom, publishing fiction, and creating visual art and comics journalism. The two careers look different. The craft is the same.
             </p>
-            <a href="/about/" class="btn btn--outline" style="--btn-outline-border: var(--ink-600); --btn-outline-text: var(--ink-900); --btn-outline-bg-hover: rgba(255,255,255,0.08);">
+            <a href="/about/" class="btn btn--outline">
               Full story →
             </a>
           </div>

--- a/css/components.css
+++ b/css/components.css
@@ -28,7 +28,7 @@
     background var(--duration-fast) var(--ease-out-expo),
     color var(--duration-fast) var(--ease-out-expo),
     border-color var(--duration-fast) var(--ease-out-expo),
-    transform var(--duration-fast) var(--ease-spring),
+    transform var(--duration-fast) var(--ease-out-expo),
     box-shadow var(--duration-fast) var(--ease-out-expo);
 }
 
@@ -461,12 +461,34 @@
       width var(--duration-fast) var(--ease-out-expo),
       height var(--duration-fast) var(--ease-out-expo),
       background var(--duration-fast) var(--ease-out-expo);
+    /* multiply: tints content in light mode; screen: visible in dark mode */
     mix-blend-mode: multiply;
+  }
+
+  /* Dark mode: multiply disappears on dark backgrounds; use screen instead */
+  [data-theme="dark"] .cursor {
+    mix-blend-mode: screen;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :not([data-theme="light"]) .cursor {
+      mix-blend-mode: screen;
+    }
   }
 
   .cursor--large {
     width: 40px;
     height: 40px;
-    background: color-mix(in srgb, var(--color-accent) 30%, transparent);
+    background: color-mix(in srgb, var(--color-accent) 40%, transparent);
+  }
+
+  [data-theme="dark"] .cursor--large {
+    background: color-mix(in srgb, var(--color-accent) 55%, transparent);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :not([data-theme="light"]) .cursor--large {
+      background: color-mix(in srgb, var(--color-accent) 55%, transparent);
+    }
   }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -62,10 +62,10 @@
 .hero {
   overflow: hidden;
   position: relative;
-  /* Even padding top and bottom — min-height fills the viewport,
-     flexbox centers the inner grid within whatever space remains */
   padding-block: clamp(var(--space-10), 6vw, var(--space-16));
-  min-height: calc(100svh - var(--nav-height));
+  /* Cap at 900px so the hero doesn't over-extend on tall screens
+     (iPad Pro portrait, large monitors, etc.) */
+  min-height: min(calc(100svh - var(--nav-height)), 900px);
   display: flex;
   align-items: center;
 }
@@ -76,44 +76,58 @@
 
 .hero__inner {
   display: grid;
-  grid-template-columns: 1fr 420px;
+  grid-template-columns: 1fr 520px;
   gap: var(--space-16);
   align-items: center;
+  position: relative;
+  z-index: 1;
 }
 
 .hero__content {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: 0;
 }
 
-/* Headline */
+/* Spacing rhythm — tight groupings, generous separations */
+.hero__content .type-eyebrow { margin-bottom: var(--space-5); }
+.hero__content .hero__headline { margin-bottom: var(--space-8); }
+.hero__content .hero__sub     { margin-bottom: var(--space-8); }
+
+/* Headline — two-line stack: "Crafted" / rotating word */
 .hero__headline {
   font-family: var(--font-display);
   font-size: var(--scale-4xl);
   font-weight: 900;
-  line-height: 1.05;
-  letter-spacing: -0.035em;
+  line-height: 1;
+  letter-spacing: -0.04em;
   color: var(--hero-display-color);
   display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0 0.25em;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0;
   margin: 0;
 }
 
-/* Rotating word container */
+/* "Crafted" — static first line */
+.hero__headline-static {
+  display: block;
+  line-height: 1;
+}
+
+/* Rotating word container — block-level, second line of headline */
 .hero__rotator {
   position: relative;
-  display: inline-block;
+  display: block;
   color: var(--hero-accent-color);
   font-style: italic;
+  /* Rotator word is 12% larger than "Crafted" — it's the statement */
+  font-size: 1.12em;
   /* Width set dynamically by JS to widest word */
   min-width: 4ch;
   /* Explicit height keeps this element in document flow so nothing
-     below it collapses up — 1.05 matches the headline line-height */
+     below it collapses up */
   height: 1.05em;
-  vertical-align: bottom;
   overflow: visible;
 }
 
@@ -173,9 +187,32 @@
 /* Photo */
 .hero__photo {
   position: relative;
-  align-self: stretch;
+  align-self: start;
   display: flex;
   align-items: flex-end;
+}
+
+/* Large "RS" monogram overlaid on the photo — outlined with transparent
+   fill so the portrait shows through. Editorial overlay technique.
+   Lives inside aria-hidden .hero__photo so screen readers ignore it. */
+.hero__rs-deco {
+  position: absolute;
+  right: -2.5rem;
+  bottom: -3rem;
+  font-family: var(--font-display);
+  font-size: clamp(10rem, 15vw, 18rem);
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: transparent;
+  -webkit-text-stroke: 2.5px var(--color-border-default);
+  user-select: none;
+  pointer-events: none;
+  /* Above photo frame (z-raised = 10) so it overlays rather than hides */
+  z-index: 15;
+  opacity: 0.5;
+  white-space: nowrap;
 }
 
 .hero__photo-frame {
@@ -202,36 +239,68 @@
   filter: grayscale(0%) contrast(1);
 }
 
-/* Decorative ember block behind photo */
+/* Decorative ember block behind photo — stronger and larger than before */
 .hero__photo-deco {
   position: absolute;
   bottom: 0;
   right: -1.5rem;
-  width: 60%;
-  height: 65%;
-  background: var(--color-accent-subtle);
+  width: 72%;
+  height: 78%;
+  background: var(--ember-700);
   border-radius: var(--radius-xl) 0 0 0;
   z-index: var(--z-below);
 }
 
-[data-theme="dark"] .hero__photo-deco,
+/* Dark mode: ember deco shifts to deep ember */
+[data-theme="dark"] .hero__photo-deco {
+  background: var(--ember-200);
+}
+
 @media (prefers-color-scheme: dark) {
   :not([data-theme="light"]) .hero__photo-deco {
-    background: var(--ember-100);
+    background: var(--ember-200);
   }
 }
 
 /* Responsive hero */
-@media (max-width: 900px) {
+@media (max-width: 1024px) {
+  .hero__inner {
+    grid-template-columns: 1fr 440px;
+    gap: var(--space-12);
+  }
+
+  /* Scale down "RS" and pull it back from the right edge to prevent
+     it from being clipped by hero's overflow:hidden at ~900–1024px */
+  .hero__rs-deco {
+    font-size: clamp(8rem, 14vw, 14rem);
+    bottom: -2rem;
+    right: -1rem;
+  }
+
+  /* Pull deco block back so it doesn't bleed past the container */
+  .hero__photo-deco {
+    right: -0.75rem;
+  }
+}
+
+@media (max-width: 860px) {
   .hero__inner {
     grid-template-columns: 1fr;
     min-height: auto;
     gap: var(--space-10);
   }
 
+  /* Keep RS visible in stacked layout — it overlays the photo nicely.
+     Scale down and tuck it just slightly past the photo's right edge. */
+  .hero__rs-deco {
+    font-size: clamp(5rem, 18vw, 8rem);
+    right: -0.5rem;
+    bottom: -1.5rem;
+  }
+
   .hero__photo {
     order: -1;
-    max-width: 320px;
+    max-width: 360px;
     margin-inline: auto;
   }
 
@@ -242,7 +311,7 @@
 
 @media (max-width: 480px) {
   .hero__photo {
-    max-width: 260px;
+    max-width: 280px;
   }
 }
 
@@ -303,8 +372,512 @@
 
 
 /* =============================================================
-   WRITING CARD — META ROW
+   WORK SHOWCASE
+   Three-tier layout replacing the uniform card grid:
+     - Hero:      full-width cinematic, flagship project
+     - Pair:      two featured projects side by side (7fr / 5fr)
+     - Secondary: compact typographic list, no images
    ============================================================= */
+
+.work-showcase {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+/* --- Hero tier --- */
+
+.work-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.work-hero__media {
+  aspect-ratio: 16 / 7;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-bg-subtle);
+  position: relative;
+}
+
+.work-hero__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform var(--duration-slower) var(--ease-out-expo);
+}
+
+.work-hero:hover .work-hero__media img {
+  transform: scale(1.015);
+}
+
+.work-hero__badge {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.3em 0.7em;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-inverse);
+  color: var(--color-text-inverse);
+  z-index: var(--z-raised);
+}
+
+.work-hero__body {
+  display: grid;
+  grid-template-columns: 5rem 1fr;
+  gap: var(--space-8);
+  align-items: start;
+  padding-top: var(--space-8);
+}
+
+.work-hero__num {
+  font-family: var(--font-display);
+  font-size: var(--scale-3xl);
+  font-weight: 900;
+  line-height: 1;
+  color: transparent;
+  -webkit-text-stroke: 1px var(--color-border-strong);
+  user-select: none;
+  padding-top: 0.1em;
+}
+
+.work-hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.work-hero__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.work-hero__title {
+  font-family: var(--font-display);
+  font-size: var(--scale-3xl);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.work-hero__title a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-out-expo);
+}
+
+.work-hero:hover .work-hero__title a {
+  color: var(--color-accent);
+}
+
+.work-hero__desc {
+  font-size: var(--scale-md);
+  color: var(--color-text-secondary);
+  line-height: 1.65;
+  max-width: 58ch;
+  margin: 0;
+}
+
+.work-hero__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+
+
+/* --- Pair tier --- */
+
+.work-pair {
+  display: grid;
+  grid-template-columns: 7fr 5fr;
+  gap: var(--space-8);
+  align-items: start;
+}
+
+.work-pair__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* image-lead: image renders first (natural order), text below */
+/* text-lead: body pulled above image via order */
+.work-pair__item--text-lead .work-pair__body { order: -1; }
+
+.work-pair__media {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-bg-subtle);
+}
+
+.work-pair__item--image-lead .work-pair__media { aspect-ratio: 4 / 3; }
+.work-pair__item--text-lead  .work-pair__media { aspect-ratio: 3 / 2; }
+
+.work-pair__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform var(--duration-slower) var(--ease-out-expo);
+}
+
+.work-pair__item:hover .work-pair__media img {
+  transform: scale(1.025);
+}
+
+.work-pair__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.work-pair__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.work-pair__title {
+  font-family: var(--font-display);
+  font-size: var(--scale-2xl);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.work-pair__title a {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--ease-out-expo);
+}
+
+.work-pair__item:hover .work-pair__title a {
+  color: var(--color-accent);
+}
+
+.work-pair__desc {
+  font-size: var(--scale-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.65;
+  margin: 0;
+}
+
+.work-pair__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+
+
+/* --- Secondary tier --- */
+
+.work-secondary {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.work-secondary__item {
+  display: grid;
+  grid-template-columns: 3rem 1fr auto auto;
+  align-items: center;
+  gap: var(--space-6);
+  padding-block: var(--space-5);
+  border-bottom: 1px solid var(--color-border-subtle);
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--duration-fast) var(--ease-out-expo),
+    padding-inline var(--duration-base) var(--ease-out-expo);
+}
+
+.work-secondary__item:hover {
+  background: var(--color-bg-elevated);
+  padding-inline: var(--space-4);
+}
+
+.work-secondary__num {
+  font-family: var(--font-mono);
+  font-size: var(--scale-xs);
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  user-select: none;
+}
+
+.work-secondary__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.work-secondary__title {
+  font-family: var(--font-display);
+  font-size: var(--scale-lg);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+  transition: color var(--duration-fast) var(--ease-out-expo);
+}
+
+.work-secondary__item:hover .work-secondary__title {
+  color: var(--color-accent);
+}
+
+.work-secondary__type {
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.work-secondary__tags {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* Cap at 2 tags to keep rows tidy */
+.work-secondary__tags .tag:nth-child(n+3) {
+  display: none;
+}
+
+.work-secondary__arrow {
+  font-size: var(--scale-md);
+  color: var(--color-text-muted);
+  transition:
+    color var(--duration-fast) var(--ease-out-expo),
+    transform var(--duration-base) var(--ease-out-expo);
+}
+
+.work-secondary__item:hover .work-secondary__arrow {
+  color: var(--color-accent);
+  transform: translateX(4px);
+}
+
+
+/* --- Responsive --- */
+
+@media (max-width: 900px) {
+  .work-pair {
+    grid-template-columns: 1fr;
+  }
+
+  /* Reset text-lead order on single column — image after body is fine */
+  .work-pair__item--text-lead .work-pair__body { order: 0; }
+}
+
+@media (max-width: 640px) {
+  .work-showcase {
+    gap: var(--space-12);
+  }
+
+  .work-hero__body {
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+
+  .work-hero__num { display: none; }
+
+  .work-secondary__item {
+    grid-template-columns: 2.5rem 1fr auto;
+  }
+
+  .work-secondary__tags { display: none; }
+}
+
+
+/* =============================================================
+   WRITING TEASER — HOME EDITORIAL LAYOUT
+   Replaces the uniform card grid with a newspaper-style hierarchy:
+     - Lead article: full-width, large italic headline, no box
+     - Pair: two columns below, separated by a rule, no boxes
+   The box styling from .card is fully neutralised in this context.
+   ============================================================= */
+
+/* Override the auto-fill grid from layout.css */
+.grid-writing--home {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  align-items: start;
+}
+
+/* Strip every trace of the generic card box */
+.grid-writing--home .card {
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  box-shadow: none;
+}
+
+.grid-writing--home .card--lift:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: transparent;
+}
+
+/* ── Lead article — headline story, spans both columns ── */
+
+.grid-writing--home > article:first-child {
+  grid-column: 1 / -1;
+  padding-bottom: var(--space-10);
+  margin-bottom: var(--space-10);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* Meta row: category · date */
+.grid-writing--home > article:first-child .card-writing__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 3px solid var(--color-accent);
+  width: fit-content;
+}
+
+/* Strip the pill from the category label in lead — plain mono text */
+.grid-writing--home > article:first-child .card-writing__cat {
+  background: none;
+  border-radius: 0;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* The big editorial headline */
+.grid-writing--home > article:first-child .card-writing__title {
+  font-size: clamp(var(--scale-2xl), 3.8vw, var(--scale-4xl));
+  font-style: italic;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  max-width: 26ch;
+  margin-bottom: var(--space-5);
+}
+
+/* Lead excerpt — visible and readable */
+.grid-writing--home > article:first-child .card-writing__excerpt {
+  -webkit-line-clamp: 3;
+  max-width: 58ch;
+  font-size: var(--scale-md);
+  line-height: 1.7;
+  margin-bottom: var(--space-5);
+}
+
+/* ── Pair articles — two columns below the rule ── */
+
+.grid-writing--home > article:nth-child(n+2) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+}
+
+/* Vertical rule between the two pair cards */
+.grid-writing--home > article:nth-child(2) {
+  padding-right: var(--space-10);
+  border-right: 1px solid var(--color-border-subtle);
+}
+
+.grid-writing--home > article:nth-child(3) {
+  padding-left: var(--space-10);
+}
+
+/* Pair meta: inline, no pill */
+.grid-writing--home > article:nth-child(n+2) .card-writing__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--scale-2xs);
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.grid-writing--home > article:nth-child(n+2) .card-writing__cat {
+  background: none;
+  border-radius: 0;
+  padding: 0;
+  color: var(--color-text-muted);
+  font-family: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+  text-transform: uppercase;
+}
+
+/* Separator dot between category and date */
+.grid-writing--home > article:nth-child(n+2) .card-writing__meta time::before {
+  content: '·';
+  margin-right: var(--space-2);
+  opacity: 0.5;
+}
+
+/* Pair headline — serif, not italic, medium size */
+.grid-writing--home > article:nth-child(n+2) .card-writing__title {
+  font-size: var(--scale-xl);
+  font-weight: 700;
+  font-style: normal;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+/* Pair excerpt — brief */
+.grid-writing--home > article:nth-child(n+2) .card-writing__excerpt {
+  -webkit-line-clamp: 3;
+  font-size: var(--scale-sm);
+}
+
+/* Responsive: collapse pair to single column on small screens */
+@media (max-width: 640px) {
+  .grid-writing--home {
+    grid-template-columns: 1fr;
+  }
+
+  .grid-writing--home > article:nth-child(2) {
+    border-right: none;
+    padding-right: 0;
+    padding-top: var(--space-8);
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  .grid-writing--home > article:nth-child(3) {
+    padding-left: 0;
+    padding-top: var(--space-8);
+    border-top: 1px solid var(--color-border-subtle);
+  }
+}
+
+/* ── Writing card meta row (used globally across home page) ── */
 
 .card-writing__meta {
   display: flex;
@@ -329,8 +902,9 @@
    ============================================================= */
 
 .about-strip {
-  /* Override section--inverse to use our custom dark bg */
-  background: var(--ink-200);
+  /* Use the semantic inverse token so this section adapts in dark mode
+     (dark in light mode, light in dark mode — correct for an inverse strip) */
+  background: var(--color-bg-inverse);
 }
 
 .about-strip__inner {
@@ -381,18 +955,38 @@
   opacity: 0;
 }
 
+/* Use color-mix so these stay readable in both light and dark mode
+   (dark bg in light mode → light-ish text; light bg in dark mode → dark-ish text) */
 .about-strip__content .type-label {
-  color: var(--ink-600);
-}
-
-.about-strip__content .type-label::before {
-  background: var(--ember-500);
+  color: color-mix(in srgb, var(--color-text-inverse) 65%, transparent);
+  /* Override --mark-color so the bar uses an ember tone in both modes */
+  --mark-color: var(--ember-500);
 }
 
 .about-strip__content h2 {
-  color: var(--ink-950);
+  color: var(--color-text-inverse);
   margin-top: var(--space-3);
   margin-bottom: var(--space-4);
+}
+
+/* Type-lead and body text — inline styles removed from template */
+.about-strip__content .type-lead {
+  color: color-mix(in srgb, var(--color-text-inverse) 85%, transparent);
+  margin-bottom: var(--space-6);
+}
+
+.about-strip__content p:not(.type-lead) {
+  color: color-mix(in srgb, var(--color-text-inverse) 70%, transparent);
+  line-height: 1.8;
+  font-size: var(--scale-md);
+  margin-bottom: var(--space-8);
+}
+
+/* Button in inverse context — adapts via token overrides */
+.about-strip__content .btn--outline {
+  --btn-outline-border: color-mix(in srgb, var(--color-text-inverse) 50%, transparent);
+  --btn-outline-text: var(--color-text-inverse);
+  --btn-outline-bg-hover: color-mix(in srgb, var(--color-text-inverse) 8%, transparent);
 }
 
 @media (max-width: 860px) {
@@ -548,10 +1142,7 @@
 }
 
 @media (max-width: 768px) {
-  .footer-inner {
-    grid-template-columns: 1fr;
-  }
-
+  /* .footer-inner breakpoint lives in layout.css (shared across all pages) */
   .footer__nav {
     gap: var(--space-8);
   }

--- a/css/layout.css
+++ b/css/layout.css
@@ -362,7 +362,8 @@
   align-items: end;
 }
 
-@media (max-width: 640px) {
+/* Footer stacks at 768px — same breakpoint used consistently across all pages */
+@media (max-width: 768px) {
   .footer-inner {
     grid-template-columns: 1fr;
     gap: var(--space-6);

--- a/css/typography.css
+++ b/css/typography.css
@@ -95,7 +95,8 @@ h6 { font-size: var(--scale-md);  line-height: 1.5;  font-weight: 600; }
   display: block;
   width: 2rem;
   height: 1px;
-  background: var(--color-accent);
+  /* Allow per-instance override via --mark-color custom property */
+  background: var(--mark-color, var(--color-accent));
   flex-shrink: 0;
 }
 

--- a/generate.py
+++ b/generate.py
@@ -192,87 +192,141 @@ def render_work_cards(projects: list) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Home page project card renderers
+# Home page work showcase renderers (hero / pair / secondary tiers)
 # ---------------------------------------------------------------------------
 
-def render_home_project_card_featured(p: dict) -> str:
-    badge = (
-        f'\n              <span class="card-project__ai-badge">{p["badge"]}</span>'
+def render_home_work_hero(p: dict) -> str:
+    """Full-width cinematic hero — the flagship project."""
+    ext = ' target="_blank" rel="noopener"' if p.get("externalLink") else ""
+    badge_html = (
+        f'\n                <span class="work-hero__badge">{p["badge"]}</span>'
         if p.get("badge") else ""
     )
-    ext = ' target="_blank" rel="noopener"' if p.get("externalLink") else ""
     title_style = ' style="text-transform: none;"' if p.get("titleNoTransform") else ""
     title_inner = f'<span{title_style}>{p["title"]}</span>' if p.get("titleNoTransform") else p["title"]
 
-    return f"""          <article class="card card-project card--featured card--lift reveal-up" role="listitem">
-            <div class="card-project__media">
-              <img
-                src="{p['thumbnail']}"
-                alt="{p['thumbnailAlt']}"
-                width="800"
-                height="450"
-                loading="lazy"
-              >{badge}
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">{p['projectType']} · {p['year']}</p>
-              <h3 class="card-project__title">{title_inner}</h3>
-              <p class="card-project__desc">
-                {p['description']}
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-{tags_html(p['tags'], indent=18)}
+    return f"""          <article class="work-hero reveal-up" aria-labelledby="hero-project-{p['id']}">
+            <a href="{p['link']}"{ext} tabindex="-1" aria-hidden="true">
+              <div class="work-hero__media">
+                <img
+                  src="{p['thumbnail']}"
+                  alt="{p['thumbnailAlt']}"
+                  width="1200"
+                  height="525"
+                  loading="lazy"
+                >{badge_html}
+              </div>
+            </a>
+            <div class="work-hero__body">
+              <span class="work-hero__num" aria-hidden="true">01</span>
+              <div class="work-hero__content">
+                <p class="work-hero__eyebrow">{p['projectType']} · {p['year']}</p>
+                <h3 id="hero-project-{p['id']}" class="work-hero__title">
+                  <a href="{p['link']}"{ext}>{title_inner}</a>
+                </h3>
+                <p class="work-hero__desc">{p['description']}</p>
+                <div class="work-hero__footer">
+                  <div class="tags">
+{tags_html(p['tags'], indent=20)}
+                  </div>
+                  <a href="{p['link']}"{ext} class="btn btn--primary btn--arrow">{p['ctaLabel']}</a>
                 </div>
-                <a href="{p['link']}"{ext} class="btn btn--ghost btn--arrow btn--sm">{p['ctaLabel']}</a>
               </div>
             </div>
           </article>"""
 
 
-def render_home_project_card_secondary(p: dict, delay_ms: int) -> str:
+def render_home_work_pair_item(p: dict, variant: str, delay_ms: int) -> str:
+    """One item in the side-by-side pair. variant: 'image-lead' or 'text-lead'."""
     ext = ' target="_blank" rel="noopener"' if p.get("externalLink") else ""
     title_style = ' style="text-transform: none;"' if p.get("titleNoTransform") else ""
     title_inner = f'<span{title_style}>{p["title"]}</span>' if p.get("titleNoTransform") else p["title"]
+    delay_attr = f' style="--reveal-delay: {delay_ms}ms"' if delay_ms else ""
 
-    return f"""          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: {delay_ms}ms">
-            <div class="card-project__media">
-              <img
-                src="{p['thumbnail']}"
-                alt="{p['thumbnailAlt']}"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">{p['projectType']} · {p['year']}</p>
-              <h3 class="card-project__title">{title_inner}</h3>
-              <p class="card-project__desc">
-                {p['description']}
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-{tags_html(p['tags'], indent=18)}
+    return f"""            <article class="work-pair__item work-pair__item--{variant} reveal-up"{delay_attr} aria-labelledby="pair-project-{p['id']}">
+              <a href="{p['link']}"{ext} tabindex="-1" aria-hidden="true">
+                <div class="work-pair__media">
+                  <img
+                    src="{p['thumbnail']}"
+                    alt="{p['thumbnailAlt']}"
+                    width="800"
+                    height="600"
+                    loading="lazy"
+                  >
                 </div>
-                <a href="{p['link']}"{ext} class="btn btn--ghost btn--arrow btn--sm">{p['ctaLabel']}</a>
+              </a>
+              <div class="work-pair__body">
+                <p class="work-pair__eyebrow">{p['projectType']} · {p['year']}</p>
+                <h3 id="pair-project-{p['id']}" class="work-pair__title">
+                  <a href="{p['link']}"{ext}>{title_inner}</a>
+                </h3>
+                <p class="work-pair__desc">{p['description']}</p>
+                <div class="work-pair__footer">
+                  <div class="tags">
+{tags_html(p['tags'], indent=20)}
+                  </div>
+                  <a href="{p['link']}"{ext} class="btn btn--ghost btn--arrow btn--sm">{p['ctaLabel']}</a>
+                </div>
               </div>
-            </div>
-          </article>"""
+            </article>"""
+
+
+def render_home_work_pair(projects: list) -> str:
+    """Two featured projects side by side — first is image-lead, second is text-lead."""
+    variants = ["image-lead", "text-lead"]
+    delays = [0, 150]
+    items = [
+        render_home_work_pair_item(p, variants[i], delays[i])
+        for i, p in enumerate(projects[:2])
+    ]
+    return (
+        "          <div class=\"work-pair\">\n"
+        + "\n\n".join(items)
+        + "\n          </div>"
+    )
+
+
+def render_home_work_secondary(projects: list) -> str:
+    """Compact typographic list for remaining projects."""
+    items = []
+    for i, p in enumerate(projects):
+        ext = ' target="_blank" rel="noopener"' if p.get("externalLink") else ""
+        num = str(i + 4).zfill(2)
+        delay_attr = f' style="--reveal-delay: {i * 100}ms"' if i > 0 else ""
+
+        items.append(
+            f"""            <a href="{p['link']}"{ext} class="work-secondary__item reveal-up"{delay_attr}>
+              <span class="work-secondary__num" aria-hidden="true">{num}</span>
+              <span class="work-secondary__info">
+                <span class="work-secondary__title">{p['title']}</span>
+                <span class="work-secondary__type">{p['projectType']} · {p['year']}</span>
+              </span>
+              <span class="work-secondary__tags" aria-hidden="true">
+{tags_html(p['tags'], indent=16)}
+              </span>
+              <span class="work-secondary__arrow" aria-hidden="true">→</span>
+            </a>"""
+        )
+
+    return (
+        "          <div class=\"work-secondary\" role=\"list\" aria-label=\"More projects\">\n"
+        + "\n\n".join(items)
+        + "\n          </div>"
+    )
 
 
 def render_home_project_cards(projects: list) -> str:
-    featured = [p for p in projects if p.get("featured")]
-    secondary = [p for p in projects if not p.get("featured")]
+    hero = [p for p in projects if p.get("homeDisplay") == "hero"]
+    pair = [p for p in projects if p.get("homeDisplay") == "pair"]
+    secondary = [p for p in projects if p.get("homeDisplay") == "secondary"]
 
     parts = []
-    for p in featured:
-        parts.append(render_home_project_card_featured(p))
-
-    delay = 100
-    for p in secondary:
-        parts.append(render_home_project_card_secondary(p, delay))
-        delay += 100
+    if hero:
+        parts.append(render_home_work_hero(hero[0]))
+    if pair:
+        parts.append(render_home_work_pair(pair))
+    if secondary:
+        parts.append(render_home_work_secondary(secondary))
 
     return "\n\n".join(parts)
 

--- a/index.html
+++ b/index.html
@@ -73,9 +73,12 @@
       <div class="container">
         <div class="hero__inner">
           <div class="hero__content">
-            <span class="type-eyebrow">Front-end engineer · Author · Artist</span>
+            <span class="type-eyebrow">
+              <span class="accent-mark" aria-hidden="true"></span>
+              Front-end engineer · Author · Artist
+            </span>
             <h1 id="hero-heading" class="hero__headline">
-              Crafted
+              <span class="hero__headline-static">Crafted</span>
               <span
                 class="hero__rotator"
                 id="hero-rotator"
@@ -91,20 +94,15 @@
               <a href="/work/" class="btn btn--primary btn--arrow btn--lg">View my work</a>
               <a href="/writing/" class="btn btn--outline btn--lg">Read my writing</a>
             </div>
-            <div class="hero__meta">
-              <span class="tag tag--tech">Angular</span>
-              <span class="tag tag--tech">TypeScript</span>
-              <span class="tag tag--tech">AI-assisted dev</span>
-              <span class="tag tag--tech">10+ years</span>
-            </div>
           </div>
           <div class="hero__photo" aria-hidden="true">
+            <span class="hero__rs-deco">RS</span>
             <div class="hero__photo-frame">
               <img
                 src="/img/headshot.jpg"
                 alt="Ryan Schill"
-                width="480"
-                height="600"
+                width="520"
+                height="650"
                 loading="eager"
                 fetchpriority="high"
               >
@@ -122,171 +120,145 @@
           <span class="type-label">Selected work</span>
           <h2 id="work-heading">Things I've built.</h2>
         </header>
-        <div class="grid-portfolio" role="list">
+        <div class="work-showcase">
           <!-- GENERATED:home-project-cards -->
-          <article class="card card-project card--featured card--lift reveal-up" role="listitem">
-            <div class="card-project__media">
-              <img
-                src="/img/project-portfolio.png"
-                alt="Screenshot of ryanschill.co"
-                width="800"
-                height="450"
-                loading="lazy"
-              >
-              <span class="card-project__ai-badge">AI-assisted build</span>
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Personal project · 2025</p>
-              <h3 class="card-project__title">This website</h3>
-              <p class="card-project__desc">
-                A complete redesign built in collaboration with an AI — from the design system up. Vanilla HTML, CSS, and JavaScript. No framework, no build step. The process turned out to be something more interesting than I expected.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--tech">HTML</span>
-                  <span class="tag tag--tech">CSS</span>
-                  <span class="tag tag--tech">JavaScript</span>
-                  <span class="tag tag--tech">Claude</span>
+          <article class="work-hero reveal-up" aria-labelledby="hero-project-portfolio">
+            <a href="/work/portfolio/" tabindex="-1" aria-hidden="true">
+              <div class="work-hero__media">
+                <img
+                  src="/img/project-portfolio.png"
+                  alt="Screenshot of ryanschill.co"
+                  width="1200"
+                  height="525"
+                  loading="lazy"
+                >
+                <span class="work-hero__badge">AI-assisted build</span>
+              </div>
+            </a>
+            <div class="work-hero__body">
+              <span class="work-hero__num" aria-hidden="true">01</span>
+              <div class="work-hero__content">
+                <p class="work-hero__eyebrow">Personal project · 2025</p>
+                <h3 id="hero-project-portfolio" class="work-hero__title">
+                  <a href="/work/portfolio/">This website</a>
+                </h3>
+                <p class="work-hero__desc">A complete redesign built in collaboration with an AI — from the design system up. Vanilla HTML, CSS, and JavaScript. No framework, no build step. The process turned out to be something more interesting than I expected.</p>
+                <div class="work-hero__footer">
+                  <div class="tags">
+                    <span class="tag tag--tech">HTML</span>
+                    <span class="tag tag--tech">CSS</span>
+                    <span class="tag tag--tech">JavaScript</span>
+                    <span class="tag tag--tech">Claude</span>
+                  </div>
+                  <a href="/work/portfolio/" class="btn btn--primary btn--arrow">Case study</a>
                 </div>
-                <a href="/work/portfolio/" class="btn btn--ghost btn--arrow btn--sm">Case study</a>
               </div>
             </div>
           </article>
 
-          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: 100ms">
-            <div class="card-project__media">
-              <img
-                src="/img/project-projectr.png"
-                alt="projectr task management app"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Side project · 2026</p>
-              <h3 class="card-project__title"><span style="text-transform: none;">projectr v2 beta</span></h3>
-              <p class="card-project__desc">
-                A task and project management app for individuals and freelancers — re-built with Angular v19 and Firebase because I wanted to focus entirely on the front end. Built for myself, because I have ADHD. Currently in private beta testing, but sign up if you want to try it out.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--tech">AngularJS</span>
-                  <span class="tag tag--tech">JavaScript</span>
-                  <span class="tag tag--tech">Firebase</span>
+          <div class="work-pair">
+            <article class="work-pair__item work-pair__item--image-lead reveal-up" aria-labelledby="pair-project-projectr-v2">
+              <a href="/work/projectr/" tabindex="-1" aria-hidden="true">
+                <div class="work-pair__media">
+                  <img
+                    src="/img/project-projectr-v2.png"
+                    alt="projectr v2 task management app"
+                    width="800"
+                    height="600"
+                    loading="lazy"
+                  >
                 </div>
-                <a href="/work/projectr/" class="btn btn--ghost btn--arrow btn--sm">Visit app</a>
+              </a>
+              <div class="work-pair__body">
+                <p class="work-pair__eyebrow">Side project · 2026</p>
+                <h3 id="pair-project-projectr-v2" class="work-pair__title">
+                  <a href="/work/projectr/"><span style="text-transform: none;">projectr v2 beta</span></a>
+                </h3>
+                <p class="work-pair__desc">A task and project management app for individuals and freelancers — re-built with Angular v19 and Firebase because I wanted to focus entirely on the front end. Built for myself, because I have ADHD. Currently in private beta testing, but sign up if you want to try it out.</p>
+                <div class="work-pair__footer">
+                  <div class="tags">
+                    <span class="tag tag--tech">Angular</span>
+                    <span class="tag tag--tech">TypeScript</span>
+                    <span class="tag tag--tech">Firebase</span>
+                  </div>
+                  <a href="/work/projectr/" class="btn btn--ghost btn--arrow btn--sm">Visit app</a>
+                </div>
               </div>
-            </div>
-          </article>
+            </article>
 
-          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: 200ms">
-            <div class="card-project__media">
-              <img
-                src="/img/project-jjie.png"
-                alt="Juvenile Justice Information Exchange website"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Journalism · 2010–2014</p>
-              <h3 class="card-project__title">Juvenile Justice Information Exchange</h3>
-              <p class="card-project__desc">
-                From intern reporter to managing editor — six years covering juvenile justice and child welfare nationally. Where writing and building first converged for me.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--writing">Journalism</span>
-                  <span class="tag tag--writing">Editing</span>
-                  <span class="tag tag--writing">Digital strategy</span>
+            <article class="work-pair__item work-pair__item--text-lead reveal-up" style="--reveal-delay: 150ms" aria-labelledby="pair-project-vanessa-schill">
+              <a href="http://vanessaschill.com" target="_blank" rel="noopener" tabindex="-1" aria-hidden="true">
+                <div class="work-pair__media">
+                  <img
+                    src="/img/project-vanessa.png"
+                    alt="Screenshot of vanessaschill.com"
+                    width="800"
+                    height="600"
+                    loading="lazy"
+                  >
                 </div>
-                <a href="/work/jjie/" class="btn btn--ghost btn--arrow btn--sm">Read more</a>
+              </a>
+              <div class="work-pair__body">
+                <p class="work-pair__eyebrow">Client project · 2026</p>
+                <h3 id="pair-project-vanessa-schill" class="work-pair__title">
+                  <a href="http://vanessaschill.com" target="_blank" rel="noopener">Vanessa Schill</a>
+                </h3>
+                <p class="work-pair__desc">Portfolio site for a senior instructional designer and ATD Master Trainer. Features a CSS marquee ticker for scrolling skills, fully responsive layout, and a clean typographic system built without a framework.</p>
+                <div class="work-pair__footer">
+                  <div class="tags">
+                    <span class="tag tag--tech">HTML</span>
+                    <span class="tag tag--tech">CSS</span>
+                    <span class="tag tag--tech">JavaScript</span>
+                  </div>
+                  <a href="http://vanessaschill.com" target="_blank" rel="noopener" class="btn btn--ghost btn--arrow btn--sm">Visit site</a>
+                </div>
               </div>
-            </div>
-          </article>
+            </article>
+          </div>
 
-          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: 300ms">
-            <div class="card-project__media">
-              <img
-                src="/img/project-vanessa.png"
-                alt="Screenshot of vanessaschill.com"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Client project · 2026</p>
-              <h3 class="card-project__title">Vanessa Schill</h3>
-              <p class="card-project__desc">
-                Portfolio site for a senior instructional designer and ATD Master Trainer. Features a CSS marquee ticker for scrolling skills, fully responsive layout, and a clean typographic system built without a framework.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--tech">HTML</span>
-                  <span class="tag tag--tech">CSS</span>
-                  <span class="tag tag--tech">JavaScript</span>
-                </div>
-                <a href="http://vanessaschill.com" target="_blank" rel="noopener" class="btn btn--ghost btn--arrow btn--sm">Visit site</a>
-              </div>
-            </div>
-          </article>
+          <div class="work-secondary" role="list" aria-label="More projects">
+            <a href="/work/jjie/" class="work-secondary__item reveal-up">
+              <span class="work-secondary__num" aria-hidden="true">04</span>
+              <span class="work-secondary__info">
+                <span class="work-secondary__title">Juvenile Justice Information Exchange</span>
+                <span class="work-secondary__type">Journalism · 2010–2014</span>
+              </span>
+              <span class="work-secondary__tags" aria-hidden="true">
+                <span class="tag tag--writing">Journalism</span>
+                <span class="tag tag--writing">Editing</span>
+                <span class="tag tag--writing">Digital strategy</span>
+              </span>
+              <span class="work-secondary__arrow" aria-hidden="true">→</span>
+            </a>
 
-          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: 400ms">
-            <div class="card-project__media">
-              <img
-                src="/img/project-phillies.png"
-                alt="Screenshot of Phillies Dashboard app"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Side project · 2026</p>
-              <h3 class="card-project__title">Phillies Dashboard</h3>
-              <p class="card-project__desc">
-                A real-time dashboard for tracking Philadelphia Phillies games, built with Angular and the MLB Stats API. Features live score updates and a responsive design for mobile devices.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--tech">Angular</span>
-                  <span class="tag tag--tech">TypeScript</span>
-                  <span class="tag tag--tech">TailwindCSS</span>
-                </div>
-                <a href="https://ryanschill.co/phillies-dashboard" target="_blank" rel="noopener" class="btn btn--ghost btn--arrow btn--sm">Visit app</a>
-              </div>
-            </div>
-          </article>
+            <a href="https://ryanschill.co/phillies-dashboard" target="_blank" rel="noopener" class="work-secondary__item reveal-up" style="--reveal-delay: 100ms">
+              <span class="work-secondary__num" aria-hidden="true">05</span>
+              <span class="work-secondary__info">
+                <span class="work-secondary__title">Phillies Dashboard</span>
+                <span class="work-secondary__type">Side project · 2026</span>
+              </span>
+              <span class="work-secondary__tags" aria-hidden="true">
+                <span class="tag tag--tech">Angular</span>
+                <span class="tag tag--tech">TypeScript</span>
+                <span class="tag tag--tech">TailwindCSS</span>
+              </span>
+              <span class="work-secondary__arrow" aria-hidden="true">→</span>
+            </a>
 
-          <article class="card card-project card--secondary card--lift reveal-up" role="listitem" style="--reveal-delay: 500ms">
-            <div class="card-project__media">
-              <img
-                src="/img/project-projectr.png"
-                alt="projectr task management app"
-                width="600"
-                height="338"
-                loading="lazy"
-              >
-            </div>
-            <div class="card-project__body">
-              <p class="card-project__eyebrow">Side project · 2016–2017</p>
-              <h3 class="card-project__title"><span style="text-transform: none;">projectr v1</span></h3>
-              <p class="card-project__desc">
-                A task and project management app for individuals and freelancers — built with AngularJS and Firebase because I wanted to focus entirely on the front end. Built for myself, because I have ADHD.
-              </p>
-              <div class="card-project__footer">
-                <div class="tags">
-                  <span class="tag tag--tech">AngularJS</span>
-                  <span class="tag tag--tech">JavaScript</span>
-                  <span class="tag tag--tech">Firebase</span>
-                </div>
-                <a href="/work/projectr/" class="btn btn--ghost btn--arrow btn--sm">Case study</a>
-              </div>
-            </div>
-          </article>
+            <a href="/work/projectr/" class="work-secondary__item reveal-up" style="--reveal-delay: 200ms">
+              <span class="work-secondary__num" aria-hidden="true">06</span>
+              <span class="work-secondary__info">
+                <span class="work-secondary__title">projectr v1</span>
+                <span class="work-secondary__type">Side project · 2016–2017</span>
+              </span>
+              <span class="work-secondary__tags" aria-hidden="true">
+                <span class="tag tag--tech">AngularJS</span>
+                <span class="tag tag--tech">JavaScript</span>
+                <span class="tag tag--tech">Firebase</span>
+              </span>
+              <span class="work-secondary__arrow" aria-hidden="true">→</span>
+            </a>
+          </div>
           <!-- /GENERATED:home-project-cards -->
         </div>
         <div class="section-footer">
@@ -305,7 +277,7 @@
           </div>
           <a href="/writing/" class="btn btn--ghost btn--arrow">All posts</a>
         </header>
-        <div class="grid-writing">
+        <div class="grid-writing grid-writing--home">
           <!-- GENERATED:home-post-cards -->
           <article class="card card-writing card--lift reveal-up">
             <p class="card-writing__meta">
@@ -373,15 +345,15 @@
             >
           </div>
           <div class="about-strip__content">
-            <span class="type-label" style="--mark-color: var(--ember-600)">About</span>
+            <span class="type-label">About</span>
             <h2 id="about-heading">I'm Ryan.</h2>
-            <p class="type-lead" style="color: var(--ink-700); margin-bottom: var(--space-6);">
+            <p class="type-lead">
               Senior front-end engineer by day. Author and visual artist by night. Journalist by training.
             </p>
-            <p style="color: var(--ink-700); margin-bottom: var(--space-8); line-height: 1.8; font-size: var(--scale-md);">
+            <p>
               I've spent a decade building front-end applications at companies like IBM, ADP, Vanguard, and NBCUniversal. Before that, I spent years writing, reporting on juvenile justice, editing and managing a newsroom, publishing fiction, and creating visual art and comics journalism. The two careers look different. The craft is the same.
             </p>
-            <a href="/about/" class="btn btn--outline" style="--btn-outline-border: var(--ink-600); --btn-outline-text: var(--ink-900); --btn-outline-bg-hover: rgba(255,255,255,0.08);">
+            <a href="/about/" class="btn btn--outline">
               Full story →
             </a>
           </div>

--- a/projects.json
+++ b/projects.json
@@ -8,6 +8,7 @@
     "link": "/work/portfolio/",
     "externalLink": false,
     "featured": true,
+    "homeDisplay": "hero",
     "ctaLabel": "Case study",
     "badge": "AI-assisted build",
     "tags": [
@@ -24,40 +25,21 @@
     "title": "projectr v2 beta",
     "titleNoTransform": true,
     "description": "A task and project management app for individuals and freelancers — re-built with Angular v19 and Firebase because I wanted to focus entirely on the front end. Built for myself, because I have ADHD. Currently in private beta testing, but sign up if you want to try it out.",
-    "thumbnail": "/img/project-projectr.png",
-    "thumbnailAlt": "projectr task management app",
+    "thumbnail": "/img/project-projectr-v2.png",
+    "thumbnailAlt": "projectr v2 task management app",
     "link": "/work/projectr/",
     "externalLink": false,
     "featured": false,
+    "homeDisplay": "pair",
     "ctaLabel": "Visit app",
     "badge": null,
     "tags": [
-      { "label": "AngularJS", "type": "tech" },
-      { "label": "JavaScript", "type": "tech" },
+      { "label": "Angular", "type": "tech" },
+      { "label": "TypeScript", "type": "tech" },
       { "label": "Firebase", "type": "tech" }
     ],
     "year": "2026",
     "projectType": "Side project"
-  },
-  {
-    "id": "jjie",
-    "title": "Juvenile Justice Information Exchange",
-    "titleNoTransform": false,
-    "description": "From intern reporter to managing editor — six years covering juvenile justice and child welfare nationally. Where writing and building first converged for me.",
-    "thumbnail": "/img/project-jjie.png",
-    "thumbnailAlt": "Juvenile Justice Information Exchange website",
-    "link": "/work/jjie/",
-    "externalLink": false,
-    "featured": false,
-    "ctaLabel": "Read more",
-    "badge": null,
-    "tags": [
-      { "label": "Journalism", "type": "writing" },
-      { "label": "Editing", "type": "writing" },
-      { "label": "Digital strategy", "type": "writing" }
-    ],
-    "year": "2010–2014",
-    "projectType": "Journalism"
   },
   {
     "id": "vanessa-schill",
@@ -69,6 +51,7 @@
     "link": "http://vanessaschill.com",
     "externalLink": true,
     "featured": false,
+    "homeDisplay": "pair",
     "ctaLabel": "Visit site",
     "badge": null,
     "tags": [
@@ -80,6 +63,27 @@
     "projectType": "Client project"
   },
   {
+    "id": "jjie",
+    "title": "Juvenile Justice Information Exchange",
+    "titleNoTransform": false,
+    "description": "From intern reporter to managing editor — six years covering juvenile justice and child welfare nationally. Where writing and building first converged for me.",
+    "thumbnail": "/img/project-jjie.png",
+    "thumbnailAlt": "Juvenile Justice Information Exchange website",
+    "link": "/work/jjie/",
+    "externalLink": false,
+    "featured": false,
+    "homeDisplay": "secondary",
+    "ctaLabel": "Read more",
+    "badge": null,
+    "tags": [
+      { "label": "Journalism", "type": "writing" },
+      { "label": "Editing", "type": "writing" },
+      { "label": "Digital strategy", "type": "writing" }
+    ],
+    "year": "2010–2014",
+    "projectType": "Journalism"
+  },
+  {
     "id": "phillies-dashboard",
     "title": "Phillies Dashboard",
     "titleNoTransform": false,
@@ -89,6 +93,7 @@
     "link": "https://ryanschill.co/phillies-dashboard",
     "externalLink": true,
     "featured": false,
+    "homeDisplay": "secondary",
     "ctaLabel": "Visit app",
     "badge": null,
     "tags": [
@@ -109,6 +114,7 @@
     "link": "/work/projectr/",
     "externalLink": false,
     "featured": false,
+    "homeDisplay": "secondary",
     "ctaLabel": "Case study",
     "badge": null,
     "tags": [

--- a/work/index.html
+++ b/work/index.html
@@ -101,8 +101,8 @@
             <a href="/work/projectr/" class="work-card__link" aria-label="View case study: projectr v2 beta">
               <div class="work-card__media">
                 <img
-                  src="/img/project-projectr.png"
-                  alt="projectr task management app"
+                  src="/img/project-projectr-v2.png"
+                  alt="projectr v2 task management app"
                   width="800"
                   height="450"
                   loading="lazy"
@@ -122,8 +122,8 @@
               </p>
               <div class="work-card__footer">
                 <div class="tags">
-                  <span class="tag tag--tech">AngularJS</span>
-                  <span class="tag tag--tech">JavaScript</span>
+                  <span class="tag tag--tech">Angular</span>
+                  <span class="tag tag--tech">TypeScript</span>
                   <span class="tag tag--tech">Firebase</span>
                 </div>
                 <a href="/work/projectr/" class="work-card__cta btn btn--outline btn--arrow btn--sm">
@@ -134,45 +134,6 @@
           </article>
 
           <article class="work-card reveal-up" style="--reveal-delay: 200ms">
-            <a href="/work/jjie/" class="work-card__link" aria-label="View case study: Juvenile Justice Information Exchange">
-              <div class="work-card__media">
-                <img
-                  src="/img/project-jjie.png"
-                  alt="Juvenile Justice Information Exchange website"
-                  width="800"
-                  height="450"
-                  loading="lazy"
-                >
-              </div>
-            </a>
-            <div class="work-card__body">
-              <div class="work-card__meta">
-                <span class="work-card__year">2010–2014</span>
-                <span class="work-card__type">Journalism</span>
-              </div>
-              <h2 class="work-card__title">
-                <a href="/work/jjie/">Juvenile Justice Information Exchange</a>
-              </h2>
-              <p class="work-card__desc">
-                From intern reporter to managing editor — six years covering juvenile justice and child welfare nationally. Where writing and building first converged for me.
-              </p>
-              <div class="work-card__footer">
-                <div class="tags">
-                  <span class="tag tag--writing">Journalism</span>
-                  <span class="tag tag--writing">Editing</span>
-                  <span class="tag tag--writing">Digital strategy</span>
-                </div>
-                <a href="/work/jjie/" class="work-card__cta btn btn--outline btn--arrow btn--sm">
-                  Read more
-                </a>
-              </div>
-            </div>
-          </article>
-
-        </div>
-
-        <div class="work-grid-row">
-          <article class="work-card reveal-up" style="--reveal-delay: 100ms">
             <a href="http://vanessaschill.com" class="work-card__link" aria-label="View case study: Vanessa Schill" target="_blank" rel="noopener">
               <div class="work-card__media">
                 <img
@@ -203,6 +164,45 @@
                 </div>
                 <a href="http://vanessaschill.com" target="_blank" rel="noopener" class="work-card__cta btn btn--outline btn--arrow btn--sm">
                   Visit site
+                </a>
+              </div>
+            </div>
+          </article>
+
+        </div>
+
+        <div class="work-grid-row">
+          <article class="work-card reveal-up" style="--reveal-delay: 100ms">
+            <a href="/work/jjie/" class="work-card__link" aria-label="View case study: Juvenile Justice Information Exchange">
+              <div class="work-card__media">
+                <img
+                  src="/img/project-jjie.png"
+                  alt="Juvenile Justice Information Exchange website"
+                  width="800"
+                  height="450"
+                  loading="lazy"
+                >
+              </div>
+            </a>
+            <div class="work-card__body">
+              <div class="work-card__meta">
+                <span class="work-card__year">2010–2014</span>
+                <span class="work-card__type">Journalism</span>
+              </div>
+              <h2 class="work-card__title">
+                <a href="/work/jjie/">Juvenile Justice Information Exchange</a>
+              </h2>
+              <p class="work-card__desc">
+                From intern reporter to managing editor — six years covering juvenile justice and child welfare nationally. Where writing and building first converged for me.
+              </p>
+              <div class="work-card__footer">
+                <div class="tags">
+                  <span class="tag tag--writing">Journalism</span>
+                  <span class="tag tag--writing">Editing</span>
+                  <span class="tag tag--writing">Digital strategy</span>
+                </div>
+                <a href="/work/jjie/" class="work-card__cta btn btn--outline btn--arrow btn--sm">
+                  Read more
                 </a>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **3-tier work showcase**: Replaces the uniform card grid with a cinematic hero (full-width, 16:7), a 7fr/5fr side-by-side pair, and a compact typographic secondary list — driven by a new `homeDisplay` field in `projects.json` with matching renderers in `generate.py`
- **Hero amplification**: Giant outlined RS monogram overlay on the headshot, ember decorative block, two-line headline with italic animated rotator word, responsive fixes to prevent clipping at ~910px and keep the monogram visible at all sizes
- **Editorial writing section**: Replaces the uniform 3-column card boxes with a newspaper-style layout — lead story spans full width with large italic headline and kicker rule, pair articles share a ruled 2-column row with no boxes
- **Polish pass**: Fixes 8 issues including invalid dark-mode CSS selectors, about strip invisible in dark mode, inline primitive colors replaced with adaptive `color-mix` CSS, button bounce easing → expo, custom cursor dark mode blend mode, `type-label::before` now respects `--mark-color` override, footer breakpoint consolidated across all pages

## Test plan

- [ ] View at desktop (1200px+), mid (900–1024px), tablet portrait (~860px), mobile (<640px)
- [ ] Toggle dark mode — about strip, hero deco, and cursor visible and correct in both
- [ ] Verify RS monogram visible at all breakpoints (no longer hidden below 860px)
- [ ] Confirm work/index.html and writing/index.html unaffected
- [ ] Hover buttons — scale without bounce; cursor visible in light and dark mode
